### PR TITLE
Bugfix in PHP 5.4

### DIFF
--- a/src/app/code/community/TS/ApiPlus/Model/Http/Request.php
+++ b/src/app/code/community/TS/ApiPlus/Model/Http/Request.php
@@ -247,7 +247,7 @@ class TS_ApiPlus_Model_Http_Request
      */
     protected function initRequestData()
     {
-        if (empty($this->getResource())) {
+        if (!($this->getResource())) {
             $this->sendHttpErrorResponse(TS_ApiPlus_Model_Http_Response::HTTP_BAD_REQUEST);
         }
 


### PR DESCRIPTION
I don't know why, but this PR resolve the error **Can't use method return value in write context** in PHP 5.4.14.

Whit this PR the response is normalized.
<img width="1094" alt="screen shot 2016-11-10 at 18 06 37" src="https://cloud.githubusercontent.com/assets/610598/20192427/f94395d2-a770-11e6-8587-3c2806ae1cf8.png">

**Aditional report**
The other PHP versions are normal.

